### PR TITLE
Build with ubi8/go-toolset

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM openshift/origin-release:golang-1.16 AS builder
-
-WORKDIR /tmp/gitops-commit-status
-COPY . /tmp/gitops-commit-status
+FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12 AS builder
+COPY . .
 RUN go build -o gitops-commit-status -mod=readonly .
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
-COPY --from=builder /tmp/gitops-commit-status/gitops-commit-status /usr/local/bin
+COPY --from=builder /opt/app-root/src/gitops-commit-status /usr/local/bin


### PR DESCRIPTION
This is necessary for multi-arch support, as OpenShift CI is still x86_64-only.

/cc @wtam2018 @chetan-rns 